### PR TITLE
Add benchmark for MSVC using VS22

### DIFF
--- a/testing/benchmarking/msvc.ps1
+++ b/testing/benchmarking/msvc.ps1
@@ -1,0 +1,51 @@
+
+# Set up MSVC environment
+$vsPath = "C:\Program Files\Microsoft Visual Studio\2022\Professional"
+
+# https://stackoverflow.com/questions/2124753/how-can-i-use-powershell-with-the-visual-studio-command-prompt
+Push-Location "$vsPath\Common7\Tools"
+cmd /c "VsDevCmd.bat&set" |
+ForEach-Object {
+  if ($_ -match "=") {
+    $v = $_.split("=", 2); set-item -force -path "ENV:\$($v[0])"  -value "$($v[1])" 
+  }
+}
+Pop-Location
+
+function AverageRuntime {
+    param ([string]$Command)
+
+    $Repetitions=5
+    
+    # Warmup
+    Invoke-Expression "$Command" 2> $null 1> $null
+    
+    Write-Host -NoNewline "Running '$Command', $Repetitions times: "
+
+    $sw = [Diagnostics.Stopwatch]::StartNew()
+    for ($i = 1; $i -le $Repetitions; $i++) {
+        Invoke-Expression "$Command" 2> $null 1> $null
+    }
+    $sw.Stop()
+    $avg = $sw.Elapsed.TotalMilliseconds / $Repetitions
+    $avg = [math]::round($avg, 1)
+    
+    Write-Host "took $avg milliseconds on average."
+}
+
+$cl = "cl.exe /std:c++latest /EHsc"
+
+
+AverageRuntime -Command "$cl /c include_necessary/hello_world.cpp"
+AverageRuntime -Command "$cl /I. /c include_all/hello_world.cpp"
+AverageRuntime -Command "$cl /c import_necessary/hello_world.cpp"
+AverageRuntime -Command "$cl /I. /c import_all/hello_world.cpp"
+AverageRuntime -Command "$cl /c import_std/hello_world.cpp"
+
+
+AverageRuntime -Command "$cl /c include_necessary/mix.cpp"
+AverageRuntime -Command "$cl /I. /c include_all/mix.cpp"
+AverageRuntime -Command "$cl /c import_necessary/mix.cpp"
+AverageRuntime -Command "$cl /I. /c import_all/mix.cpp"
+AverageRuntime -Command "$cl /c import_std/mix.cpp"
+


### PR DESCRIPTION
Tested on my laptop with an i7-14700HX results:
```
Running 'cl.exe /std:c++latest /EHsc /c include_necessary/hello_world.cpp', 5 times: took 586.5 milliseconds on average.
Running 'cl.exe /std:c++latest /EHsc /I. /c include_all/hello_world.cpp', 5 times: took 1772.6 milliseconds on average.
Running 'cl.exe /std:c++latest /EHsc /c import_necessary/hello_world.cpp', 5 times: took 47 milliseconds on average.
Running 'cl.exe /std:c++latest /EHsc /I. /c import_all/hello_world.cpp', 5 times: took 49.5 milliseconds on average.
Running 'cl.exe /std:c++latest /EHsc /c import_std/hello_world.cpp', 5 times: took 56.5 milliseconds on average.
Running 'cl.exe /std:c++latest /EHsc /c include_necessary/mix.cpp', 5 times: took 1089.5 milliseconds on average.
Running 'cl.exe /std:c++latest /EHsc /I. /c include_all/mix.cpp', 5 times: took 1847.6 milliseconds on average.
Running 'cl.exe /std:c++latest /EHsc /c import_necessary/mix.cpp', 5 times: took 50.2 milliseconds on average.
Running 'cl.exe /std:c++latest /EHsc /I. /c import_all/mix.cpp', 5 times: took 51.4 milliseconds on average.
Running 'cl.exe /std:c++latest /EHsc /c import_std/mix.cpp', 5 times: took 50.6 milliseconds on average.
```